### PR TITLE
Add fuchsia triple

### DIFF
--- a/include/llvm-c/Core.h
+++ b/include/llvm-c/Core.h
@@ -1691,7 +1691,7 @@ void LLVMSetGC(LLVMValueRef Fn, const char *Name);
  *
  * @see llvm::Function::addAttribute()
  */
-void LLVMAddFunctionAttr(LLVMValueRef Fn, LLVMAttribute PA);
+void LLVMAddFunctionAttr(LLVMValueRef Fn, unsigned PA, unsigned HighPA);
 
 /**
  * Obtain an attribute from a function.

--- a/include/llvm/IR/Attributes.h
+++ b/include/llvm/IR/Attributes.h
@@ -68,6 +68,7 @@ public:
                            ///< 0 means unaligned (different from align(1))
     AlwaysInline,          ///< inline=always
     ByVal,                 ///< Pass structure by value
+    FixedStackSegment,     ///< Fixed-size stack segment
     InlineHint,            ///< Source said inlining was desirable
     InReg,                 ///< Force argument to be passed in register
     MinSize,               ///< Function must be optimized for size first

--- a/include/llvm/Target/TargetOptions.h
+++ b/include/llvm/Target/TargetOptions.h
@@ -208,6 +208,10 @@ namespace llvm {
     /// the value of this option.
     FPOpFusion::FPOpFusionMode AllowFPOpFusion;
 
+    /// The size of the stack segment to use for functions with fixed-size
+    /// stack segments, in bytes.
+    unsigned FixedStackSegmentSize;
+
   };
 } // End llvm namespace
 

--- a/lib/AsmParser/LLLexer.cpp
+++ b/lib/AsmParser/LLLexer.cpp
@@ -593,6 +593,7 @@ lltok::Kind LLLexer::LexIdentifier() {
   KEYWORD(sanitize_memory);
   KEYWORD(uwtable);
   KEYWORD(zeroext);
+  KEYWORD(fixedstacksegment);
 
   KEYWORD(type);
   KEYWORD(opaque);

--- a/lib/AsmParser/LLParser.cpp
+++ b/lib/AsmParser/LLParser.cpp
@@ -1159,17 +1159,18 @@ bool LLParser::ParseOptionalParamAttrs(AttrBuilder &B) {
     case lltok::kw_sret:            B.addAttribute(Attribute::StructRet); break;
     case lltok::kw_zeroext:         B.addAttribute(Attribute::ZExt); break;
 
-    case lltok::kw_alignstack:      case lltok::kw_nounwind:
-    case lltok::kw_alwaysinline:    case lltok::kw_optsize:
-    case lltok::kw_inlinehint:      case lltok::kw_readnone:
-    case lltok::kw_minsize:         case lltok::kw_readonly:
-    case lltok::kw_naked:           case lltok::kw_returns_twice:
-    case lltok::kw_nobuiltin:       case lltok::kw_sanitize_address:
-    case lltok::kw_noimplicitfloat: case lltok::kw_sanitize_memory:
-    case lltok::kw_noinline:        case lltok::kw_sanitize_thread:
-    case lltok::kw_nonlazybind:     case lltok::kw_ssp:
-    case lltok::kw_noredzone:       case lltok::kw_sspreq:
-    case lltok::kw_noreturn:        case lltok::kw_uwtable:
+    case lltok::kw_alignstack:       case lltok::kw_nounwind:
+    case lltok::kw_alwaysinline:     case lltok::kw_fixedstacksegment:
+    case lltok::kw_optsize:          case lltok::kw_inlinehint:
+    case lltok::kw_readnone:         case lltok::kw_minsize:
+    case lltok::kw_readonly:         case lltok::kw_naked:
+    case lltok::kw_returns_twice:    case lltok::kw_nobuiltin:
+    case lltok::kw_sanitize_address: case lltok::kw_noimplicitfloat:
+    case lltok::kw_sanitize_memory:  case lltok::kw_noinline:
+    case lltok::kw_sanitize_thread:  case lltok::kw_nonlazybind:
+    case lltok::kw_ssp:              case lltok::kw_noredzone:
+    case lltok::kw_sspreq:           case lltok::kw_noreturn:
+    case lltok::kw_uwtable:
       HaveError |= Error(Lex.getLoc(), "invalid use of function-only attribute");
       break;
     }

--- a/lib/AsmParser/LLToken.h
+++ b/lib/AsmParser/LLToken.h
@@ -96,6 +96,7 @@ namespace lltok {
     kw_alwaysinline,
     kw_sanitize_address,
     kw_byval,
+    kw_fixedstacksegment,
     kw_inlinehint,
     kw_inreg,
     kw_minsize,

--- a/lib/IR/Attributes.cpp
+++ b/lib/IR/Attributes.cpp
@@ -211,6 +211,8 @@ std::string Attribute::getAsString(bool InAttrGrp) const {
     return "sanitize_thread";
   if (hasAttribute(Attribute::SanitizeMemory))
     return "sanitize_memory";
+  if (hasAttribute(Attribute::FixedStackSegment))
+    return "fixedstacksegment";
   if (hasAttribute(Attribute::UWTable))
     return "uwtable";
   if (hasAttribute(Attribute::ZExt))
@@ -393,6 +395,7 @@ uint64_t AttributeImpl::getAttrMask(Attribute::AttrKind Val) {
   case Attribute::SanitizeThread:  return 1ULL << 36;
   case Attribute::SanitizeMemory:  return 1ULL << 37;
   case Attribute::NoBuiltin:       return 1ULL << 38;
+  case Attribute::FixedStackSegment:  return 1ULL << 39;
   }
   llvm_unreachable("Unsupported attribute type");
 }
@@ -1133,7 +1136,8 @@ void AttrBuilder::removeFunctionOnlyAttrs() {
     .removeAttribute(Attribute::SanitizeMemory)
     .removeAttribute(Attribute::MinSize)
     .removeAttribute(Attribute::NoDuplicate)
-    .removeAttribute(Attribute::NoBuiltin);
+    .removeAttribute(Attribute::NoBuiltin)
+    .removeAttribute(Attribute::FixedStackSegment);
 }
 
 AttrBuilder &AttrBuilder::addRawValue(uint64_t Val) {

--- a/lib/IR/Core.cpp
+++ b/lib/IR/Core.cpp
@@ -1385,10 +1385,11 @@ void LLVMSetGC(LLVMValueRef Fn, const char *GC) {
     F->clearGC();
 }
 
-void LLVMAddFunctionAttr(LLVMValueRef Fn, LLVMAttribute PA) {
+void LLVMAddFunctionAttr(LLVMValueRef Fn, unsigned PA, unsigned HighPA) {
   Function *Func = unwrap<Function>(Fn);
   const AttributeSet PAL = Func->getAttributes();
-  AttrBuilder B(PA);
+  AttrBuilder B(((unsigned long long)PA) |
+                (((unsigned long long)HighPA) << 32));
   const AttributeSet PALnew =
     PAL.addAttributes(Func->getContext(), AttributeSet::FunctionIndex,
                       AttributeSet::get(Func->getContext(),

--- a/lib/Target/AArch64/AArch64Subtarget.h
+++ b/lib/Target/AArch64/AArch64Subtarget.h
@@ -47,6 +47,9 @@ public:
 
   bool isTargetELF() const { return TargetTriple.isOSBinFormatELF(); }
   bool isTargetLinux() const { return TargetTriple.getOS() == Triple::Linux; }
+  bool isTargetAndroid() const {
+    return TargetTriple.getEnvironment() == Triple::Android;
+  }
 
 };
 } // End llvm namespace

--- a/lib/Target/ARM/ARMFrameLowering.cpp
+++ b/lib/Target/ARM/ARMFrameLowering.cpp
@@ -1470,13 +1470,12 @@ void
 ARMFrameLowering::adjustForSegmentedStacks(MachineFunction &MF) const {
   const ARMSubtarget *ST = &MF.getTarget().getSubtarget<ARMSubtarget>();
 
- 
   // Doesn't support vararg function.
   if (MF.getFunction()->isVarArg())
     report_fatal_error("Segmented stacks do not support vararg functions.");
   // Doesn't support other than android.
   if (!ST->isTargetAndroid())
-    report_fatal_error("Segmented stacks not supported on this platfrom.");
+    report_fatal_error("Segmented statks not supported on this platfrom.");
   
   MachineBasicBlock &prologueMBB = MF.front();
   MachineFrameInfo* MFI = MF.getFrameInfo();
@@ -1527,9 +1526,9 @@ ARMFrameLowering::adjustForSegmentedStacks(MachineFunction &MF) const {
   // push {SR0, SR1}
   AddDefaultPred(BuildMI(prevStackMBB, DL, TII.get(ARM::STMDB_UPD))
                  .addReg(ARM::SP, RegState::Define)
-                 .addReg(ARM::SP, RegState::Define))
-    .addReg(ScratchReg0, RegState::Define)
-    .addReg(ScratchReg1, RegState::Define);
+                 .addReg(ARM::SP))
+    .addReg(ScratchReg0)
+    .addReg(ScratchReg1);
 
   if (CompareStackPointer) {
     // mov SR1, sp
@@ -1589,8 +1588,8 @@ ARMFrameLowering::adjustForSegmentedStacks(MachineFunction &MF) const {
   // push {lr} - Save return address of this function.
   AddDefaultPred(BuildMI(allocMBB, DL, TII.get(ARM::STMDB_UPD))
                  .addReg(ARM::SP, RegState::Define)
-                 .addReg(ARM::SP, RegState::Define))
-    .addReg(ARM::LR, RegState::Define);
+                 .addReg(ARM::SP))
+    .addReg(ARM::LR);
 
   // Call __morestack().
   BuildMI(allocMBB, DL, TII.get(ARM::BL))
@@ -1600,8 +1599,8 @@ ARMFrameLowering::adjustForSegmentedStacks(MachineFunction &MF) const {
   // pop {lr}
   AddDefaultPred(BuildMI(allocMBB, DL, TII.get(ARM::LDMIA_UPD))
                  .addReg(ARM::SP, RegState::Define)
-                 .addReg(ARM::SP, RegState::Define))
-    .addReg(ARM::LR, RegState::Define);
+                 .addReg(ARM::SP))
+    .addReg(ARM::LR);
 
 
   // Restore SR0 and SR1 in case of __morestack() was called.
@@ -1610,9 +1609,9 @@ ARMFrameLowering::adjustForSegmentedStacks(MachineFunction &MF) const {
   // pop {SR0, SR1}
   AddDefaultPred(BuildMI(allocMBB, DL, TII.get(ARM::LDMIA_UPD))
                  .addReg(ARM::SP, RegState::Define)
-                 .addReg(ARM::SP, RegState::Define))
-    .addReg(ScratchReg0, RegState::Define)
-    .addReg(ScratchReg1, RegState::Define);
+                 .addReg(ARM::SP))
+    .addReg(ScratchReg0)
+    .addReg(ScratchReg1);
 
   // Return from this function.
   AddDefaultPred(BuildMI(allocMBB, DL, TII.get(ARM::MOVr), ARM::PC)
@@ -1622,9 +1621,9 @@ ARMFrameLowering::adjustForSegmentedStacks(MachineFunction &MF) const {
   // pop {SR0, SR1}
   AddDefaultPred(BuildMI(postStackMBB, DL, TII.get(ARM::LDMIA_UPD))
                  .addReg(ARM::SP, RegState::Define)
-                 .addReg(ARM::SP, RegState::Define))
-    .addReg(ScratchReg0, RegState::Define)
-    .addReg(ScratchReg1, RegState::Define);
+                 .addReg(ARM::SP))
+    .addReg(ScratchReg0)
+    .addReg(ScratchReg1);
 
   // Organizing MBB lists
   postStackMBB->addSuccessor(&prologueMBB);

--- a/lib/Target/ARM/ARMFrameLowering.cpp
+++ b/lib/Target/ARM/ARMFrameLowering.cpp
@@ -1511,7 +1511,16 @@ ARMFrameLowering::adjustForSegmentedStacks(MachineFunction &MF) const {
   MF.push_front(prevStackMBB);
 
   // The required stack size that is aligend to ARM constant critarion.
-  AlignedStackSize = AlignToARMConstant(MFI->getStackSize());
+  uint64_t StackSize = MFI->getStackSize();
+
+  // If the front-end requested a fixed stack segment size, use that.
+  const Function *Fn = MF.getFunction();
+  if (Fn->getAttributes().hasAttribute(AttributeSet::FunctionIndex,
+                                       Attribute::FixedStackSegment)) {
+    StackSize = MF.getTarget().Options.FixedStackSegmentSize;
+  }
+
+  AlignedStackSize = AlignToARMConstant(StackSize);
 
   // When the frame size is less than 256 we just compare the stack
   // boundary directly to the value of the stack pointer, per gcc.

--- a/lib/Target/ARM/ARMFrameLowering.cpp
+++ b/lib/Target/ARM/ARMFrameLowering.cpp
@@ -14,7 +14,9 @@
 #include "ARMFrameLowering.h"
 #include "ARMBaseInstrInfo.h"
 #include "ARMBaseRegisterInfo.h"
+#include "ARMInstrInfo.h"
 #include "ARMMachineFunctionInfo.h"
+#include "ARMTargetMachine.h"
 #include "MCTargetDesc/ARMAddressingModes.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
@@ -1428,3 +1430,213 @@ eliminateCallFramePseudoInstr(MachineFunction &MF, MachineBasicBlock &MBB,
   MBB.erase(I);
 }
 
+// Get minimum constant for ARM instruction set that is greator than 
+// or equal to the argument.
+// In ARM instruction, constant can have any value that can be
+// produced by rotating an 8-bit value right by and even number
+// of bits within a 32-bit word.
+static uint32_t AlignToARMConstant(uint32_t Value) {
+  unsigned Shifted = 0;
+
+  if (Value == 0)
+      return 0;
+
+  while (!(Value & 0xC0000000)) {
+      Value = Value << 2;
+      Shifted += 2;
+  }
+
+  bool Carry = (Value & 0x00FFFFFF);
+  Value = ((Value & 0xFF000000) >> 24) + Carry;
+
+  if (Value & 0x0000100)
+      Value = Value & 0x000001FC;
+
+  if (Shifted > 24)
+      Value = Value >> (Shifted - 24);
+  else 
+      Value = Value << (24 - Shifted);
+
+  return Value;
+}
+
+// The stack limit in the TCB is set to this manyu bytes above the actual 
+// stack limit.
+static const uint64_t kSplitStackAvailable = 256;
+
+// Adjust function prologue to enable split stack.
+// Only support android.
+void 
+ARMFrameLowering::adjustForSegmentedStacks(MachineFunction &MF) const {
+  const ARMSubtarget *ST = &MF.getTarget().getSubtarget<ARMSubtarget>();
+
+ 
+  // Doesn't support vararg function.
+  if (MF.getFunction()->isVarArg())
+    report_fatal_error("Segmented stacks do not support vararg functions.");
+  // Doesn't support other than android.
+  if (!ST->isTargetAndroid())
+    report_fatal_error("Segmented stacks not supported on this platfrom.");
+  
+  MachineBasicBlock &prologueMBB = MF.front();
+  MachineFrameInfo* MFI = MF.getFrameInfo();
+  const ARMBaseInstrInfo &TII = *TM.getInstrInfo();
+  ARMFunctionInfo* ARMFI = MF.getInfo<ARMFunctionInfo>();
+  DebugLoc DL;
+
+  // Use R4 and R5 as scratch register.
+  // We should save R4 and R5 before use it and restore before
+  // leave the function.
+  unsigned ScratchReg0 = ARM::R4;
+  unsigned ScratchReg1 = ARM::R5;
+  // Use the last tls slot.
+  unsigned TlsOffset = 63;
+  uint64_t AlignedStackSize;
+
+  MachineBasicBlock* prevStackMBB = MF.CreateMachineBasicBlock();
+  MachineBasicBlock* postStackMBB = MF.CreateMachineBasicBlock();
+  MachineBasicBlock* allocMBB = MF.CreateMachineBasicBlock();
+  MachineBasicBlock* checkMBB = MF.CreateMachineBasicBlock();
+
+  for (MachineBasicBlock::livein_iterator i = prologueMBB.livein_begin(),
+         e = prologueMBB.livein_end(); i != e; ++i) {
+    allocMBB->addLiveIn(*i);
+    checkMBB->addLiveIn(*i);
+    prevStackMBB->addLiveIn(*i);
+    postStackMBB->addLiveIn(*i);
+  }
+
+  MF.push_front(postStackMBB);
+  MF.push_front(allocMBB);
+  MF.push_front(checkMBB);
+  MF.push_front(prevStackMBB);
+
+  // The required stack size that is aligend to ARM constant critarion.
+  AlignedStackSize = AlignToARMConstant(MFI->getStackSize());
+
+  // When the frame size is less than 256 we just compare the stack
+  // boundary directly to the value of the stack pointer, per gcc.
+  bool CompareStackPointer = AlignedStackSize < kSplitStackAvailable;
+
+  // We will use two of callee save registers as scratch register so we
+  // need to save those registers into stack frame before use it.
+  // We will use SR0 to hold stack limit and SR1 to stack size requested.
+  // and arguments for __morestack().
+  // SR0: Scratch Register #0
+  // SR1: Scratch Register #1
+  // push {SR0, SR1}
+  AddDefaultPred(BuildMI(prevStackMBB, DL, TII.get(ARM::STMDB_UPD))
+                 .addReg(ARM::SP, RegState::Define)
+                 .addReg(ARM::SP, RegState::Define))
+    .addReg(ScratchReg0, RegState::Define)
+    .addReg(ScratchReg1, RegState::Define);
+
+  if (CompareStackPointer) {
+    // mov SR1, sp
+    AddDefaultPred(BuildMI(checkMBB, DL, TII.get(ARM::MOVr), ScratchReg1)
+                   .addReg(ARM::SP)).addReg(0);
+  } else {
+    // sub SR1, sp, #StackSize
+    AddDefaultPred(BuildMI(checkMBB, DL, TII.get(ARM::SUBri), ScratchReg1)
+                   .addReg(ARM::SP).addImm(AlignedStackSize)).addReg(0);
+  }
+ 
+  // Get TLS base address.
+  // mrc p15, #0, SR0, c13, c0, #3
+  AddDefaultPred(BuildMI(checkMBB, DL, TII.get(ARM::MRC), ScratchReg0)
+                 .addImm(15)
+                 .addImm(0)
+                 .addImm(13)
+                 .addImm(0)
+                 .addImm(3));
+
+  // The last slot, assume that the last tls slot holds the stack limit
+  // add SR0, SR0, #252
+  AddDefaultPred(BuildMI(checkMBB, DL, TII.get(ARM::ADDri), ScratchReg0)
+                 .addReg(ScratchReg0).addImm(4*TlsOffset)).addReg(0);
+
+  // Get stack limit.
+  // ldr SR0, [sr0]
+  AddDefaultPred(BuildMI(checkMBB, DL, TII.get(ARM::LDRi12), ScratchReg0)
+                 .addReg(ScratchReg0).addImm(0));
+
+  // Compare stack limit with stack size requested.
+  // cmp SR0, SR1
+  AddDefaultPred(BuildMI(checkMBB, DL, TII.get(ARM::CMPrr))
+                 .addReg(ScratchReg0)
+                 .addReg(ScratchReg1));
+
+  // This jump is taken if StackLimit < SP - stack required.
+  BuildMI(checkMBB, DL, TII.get(ARM::Bcc)).addMBB(postStackMBB)
+    .addImm(ARMCC::LO)
+    .addReg(ARM::CPSR);
+
+
+  // Calling __morestack(StackSize, Size of stack arguments).
+  // __morestack knows that the stack size requested is in SR0(r4)
+  // and amount size of stack arguments is in SR1(r5).
+
+  // Pass first argument for the __morestack by Scratch Register #0.
+  //   The amount size of stack required
+  AddDefaultPred(BuildMI(allocMBB, DL, TII.get(ARM::MOVi), ScratchReg0)
+                 .addImm(AlignedStackSize)).addReg(0);
+  // Pass second argument for the __morestack by Scratch Register #1.
+  //   The amount size of stack consumed to save function arguments.
+  AddDefaultPred(BuildMI(allocMBB, DL, TII.get(ARM::MOVi), ScratchReg1)
+                 .addImm(AlignToARMConstant(ARMFI->getArgumentStackSize())))
+                 .addReg(0);
+
+  // push {lr} - Save return address of this function.
+  AddDefaultPred(BuildMI(allocMBB, DL, TII.get(ARM::STMDB_UPD))
+                 .addReg(ARM::SP, RegState::Define)
+                 .addReg(ARM::SP, RegState::Define))
+    .addReg(ARM::LR, RegState::Define);
+
+  // Call __morestack().
+  BuildMI(allocMBB, DL, TII.get(ARM::BL))
+    .addExternalSymbol("__morestack");
+  
+  // Restore return address of this original function.
+  // pop {lr}
+  AddDefaultPred(BuildMI(allocMBB, DL, TII.get(ARM::LDMIA_UPD))
+                 .addReg(ARM::SP, RegState::Define)
+                 .addReg(ARM::SP, RegState::Define))
+    .addReg(ARM::LR, RegState::Define);
+
+
+  // Restore SR0 and SR1 in case of __morestack() was called.
+  // __morestack() will skip postStackMBB block so we need to restore
+  // scratch registers from here.
+  // pop {SR0, SR1}
+  AddDefaultPred(BuildMI(allocMBB, DL, TII.get(ARM::LDMIA_UPD))
+                 .addReg(ARM::SP, RegState::Define)
+                 .addReg(ARM::SP, RegState::Define))
+    .addReg(ScratchReg0, RegState::Define)
+    .addReg(ScratchReg1, RegState::Define);
+
+  // Return from this function.
+  AddDefaultPred(BuildMI(allocMBB, DL, TII.get(ARM::MOVr), ARM::PC)
+                 .addReg(ARM::LR)).addReg(0);
+
+  // Restore SR0 and SR1 in case of __morestack() was not called.
+  // pop {SR0, SR1}
+  AddDefaultPred(BuildMI(postStackMBB, DL, TII.get(ARM::LDMIA_UPD))
+                 .addReg(ARM::SP, RegState::Define)
+                 .addReg(ARM::SP, RegState::Define))
+    .addReg(ScratchReg0, RegState::Define)
+    .addReg(ScratchReg1, RegState::Define);
+
+  // Organizing MBB lists
+  postStackMBB->addSuccessor(&prologueMBB);
+
+  allocMBB->addSuccessor(postStackMBB);
+  
+  checkMBB->addSuccessor(postStackMBB);
+  checkMBB->addSuccessor(allocMBB);
+  
+  prevStackMBB->addSuccessor(checkMBB);
+
+#ifdef XDEBUG
+  MF.verify();
+#endif
+}

--- a/lib/Target/ARM/ARMFrameLowering.h
+++ b/lib/Target/ARM/ARMFrameLowering.h
@@ -23,12 +23,14 @@ namespace llvm {
 
 class ARMFrameLowering : public TargetFrameLowering {
 protected:
+  const ARMBaseTargetMachine &TM;
   const ARMSubtarget &STI;
 
 public:
-  explicit ARMFrameLowering(const ARMSubtarget &sti)
+  explicit ARMFrameLowering(const ARMBaseTargetMachine& tm,
+                            const ARMSubtarget &sti)
     : TargetFrameLowering(StackGrowsDown, sti.getStackAlignment(), 0, 4),
-      STI(sti) {
+      TM(tm), STI(sti) {
   }
 
   /// emitProlog/emitEpilog - These methods insert prolog and epilog code into
@@ -58,6 +60,8 @@ public:
 
   void processFunctionBeforeCalleeSavedScan(MachineFunction &MF,
                                             RegScavenger *RS) const;
+
+  void adjustForSegmentedStacks(MachineFunction &MF) const;
 
  private:
   void emitPushInst(MachineBasicBlock &MBB, MachineBasicBlock::iterator MI,

--- a/lib/Target/ARM/ARMISelLowering.cpp
+++ b/lib/Target/ARM/ARMISelLowering.cpp
@@ -2819,6 +2819,8 @@ ARMTargetLowering::LowerFormalArguments(SDValue Chain,
     VarArgStyleRegisters(CCInfo, DAG, dl, Chain, 0, 0,
                          CCInfo.getNextStackOffset());
 
+  AFI->setArgumentStackSize(CCInfo.getNextStackOffset());
+
   return Chain;
 }
 

--- a/lib/Target/ARM/ARMMachineFunctionInfo.h
+++ b/lib/Target/ARM/ARMMachineFunctionInfo.h
@@ -113,6 +113,10 @@ class ARMFunctionInfo : public MachineFunctionInfo {
   /// relocation models.
   unsigned GlobalBaseReg;
 
+  /// ArgumentStackSize - amount of bytes on stack consumed by the arguments
+  /// being passed on the stack
+  unsigned ArgumentStackSize;
+
 public:
   ARMFunctionInfo() :
     isThumb(false),
@@ -174,6 +178,9 @@ public:
   void setGPRCalleeSavedArea1Size(unsigned s) { GPRCS1Size = s; }
   void setGPRCalleeSavedArea2Size(unsigned s) { GPRCS2Size = s; }
   void setDPRCalleeSavedAreaSize(unsigned s)  { DPRCSSize = s; }
+
+  unsigned getArgumentStackSize() const { return ArgumentStackSize; }
+  void setArgumentStackSize(unsigned size) { ArgumentStackSize = size; }
 
   bool isGPRCalleeSavedArea1Frame(int fi) const {
     if (fi < 0 || fi >= (int)GPRCS1Frames.size())

--- a/lib/Target/ARM/ARMSubtarget.h
+++ b/lib/Target/ARM/ARMSubtarget.h
@@ -263,6 +263,9 @@ public:
     return TargetTriple.getOS() == Triple::NaCl;
   }
   bool isTargetELF() const { return !isTargetDarwin(); }
+  bool isTargetAndroid() const {
+    return TargetTriple.getEnvironment() == Triple::Android;
+  }
 
   bool isAPCS_ABI() const { return TargetABI == ARM_ABI_APCS; }
   bool isAAPCS_ABI() const { return TargetABI == ARM_ABI_AAPCS; }

--- a/lib/Target/ARM/ARMTargetMachine.cpp
+++ b/lib/Target/ARM/ARMTargetMachine.cpp
@@ -84,7 +84,7 @@ ARMTargetMachine::ARMTargetMachine(const Target &T, StringRef TT,
                            "v128:64:128-v64:64:64-n32-S32")),
     TLInfo(*this),
     TSInfo(*this),
-    FrameLowering(Subtarget) {
+    FrameLowering(*this, Subtarget) {
   if (!Subtarget.hasARMOps())
     report_fatal_error("CPU: '" + Subtarget.getCPUString() + "' does not "
                        "support ARM mode execution!");
@@ -115,8 +115,8 @@ ThumbTargetMachine::ThumbTargetMachine(const Target &T, StringRef TT,
     TLInfo(*this),
     TSInfo(*this),
     FrameLowering(Subtarget.hasThumb2()
-              ? new ARMFrameLowering(Subtarget)
-              : (ARMFrameLowering*)new Thumb1FrameLowering(Subtarget)) {
+              ? new ARMFrameLowering(*this, Subtarget)
+              : (ARMFrameLowering*)new Thumb1FrameLowering(*this, Subtarget)) {
 }
 
 namespace {

--- a/lib/Target/ARM/ARMTargetMachine.h
+++ b/lib/Target/ARM/ARMTargetMachine.h
@@ -61,6 +61,10 @@ public:
   virtual TargetPassConfig *createPassConfig(PassManagerBase &PM);
 
   virtual bool addCodeEmitter(PassManagerBase &PM, JITCodeEmitter &MCE);
+
+  virtual const ARMBaseInstrInfo *getInstrInfo() const {
+    llvm_unreachable("getInstrInfo not implemented");
+  }
 };
 
 /// ARMTargetMachine - ARM target machine.

--- a/lib/Target/ARM/Thumb1FrameLowering.h
+++ b/lib/Target/ARM/Thumb1FrameLowering.h
@@ -22,12 +22,14 @@
 #include "llvm/Target/TargetFrameLowering.h"
 
 namespace llvm {
+  class ARMBaseTargetMachine;
   class ARMSubtarget;
 
 class Thumb1FrameLowering : public ARMFrameLowering {
 public:
-  explicit Thumb1FrameLowering(const ARMSubtarget &sti)
-    : ARMFrameLowering(sti) {
+  explicit Thumb1FrameLowering(const ARMBaseTargetMachine &tm,
+                               const ARMSubtarget &sti)
+    : ARMFrameLowering(tm, sti) {
   }
 
   /// emitProlog/emitEpilog - These methods insert prolog and epilog code into

--- a/lib/Target/X86/X86FrameLowering.cpp
+++ b/lib/Target/X86/X86FrameLowering.cpp
@@ -1472,6 +1472,13 @@ X86FrameLowering::adjustForSegmentedStacks(MachineFunction &MF) const {
   // prologue.
   StackSize = MFI->getStackSize();
 
+  // If the front-end requested a fixed stack segment size, use that.
+  const Function *Fn = MF.getFunction();
+  if (Fn->getAttributes().hasAttribute(AttributeSet::FunctionIndex,
+                                       Attribute::FixedStackSegment)) {
+    StackSize = MF.getTarget().Options.FixedStackSegmentSize;
+  }
+
   // When the frame size is less than 256 we just compare the stack
   // boundary directly to the value of the stack pointer, per gcc.
   bool CompareStackPointer = StackSize < kSplitStackAvailable;

--- a/lib/Transforms/IPO/Inliner.cpp
+++ b/lib/Transforms/IPO/Inliner.cpp
@@ -127,6 +127,12 @@ static bool InlineCallIfPossible(CallSite CS, InlineFunctionInfo &IFI,
 
   AdjustCallerSSPLevel(Caller, Callee);
 
+  // If the inlined function has a fixed stack segment, then make the caller
+  // have a fixed stack segment as well.
+  if (Callee->getAttributes().hasAttribute(AttributeSet::FunctionIndex,
+                                           Attribute::FixedStackSegment))
+    Caller->addFnAttr(Attribute::FixedStackSegment);
+
   // Look at all of the allocas that we inlined through this call site.  If we
   // have already inlined other allocas through other calls into this function,
   // then we know that they have disjoint lifetimes and that we can merge them.

--- a/test/Transforms/SimplifyCFG/switch-to-icmp.ll
+++ b/test/Transforms/SimplifyCFG/switch-to-icmp.ll
@@ -37,3 +37,21 @@ lor.end:
 ; CHECK: @test2
 ; CHECK: %switch = icmp ult i32 %x, 2
 }
+
+define i32 @test3(i1 %flag) {
+entry:
+ switch i1 %flag, label %bad [
+   i1 true, label %good
+   i1 false, label %good
+ ]
+
+good:
+ ret i32 0
+
+bad:
+ ret i32 1
+
+; CHECK: @test3
+; CHECK: entry:
+; CHECK-NEXT: ret i32 0
+}


### PR DESCRIPTION
This patch adds triples for the Fuchsia operating system. It's already been applied to upstream LLVM, so this is a backport to the 3.9 release that's currently used to build Rust.
